### PR TITLE
Enhancement: Added a new Docker plugin for RaspAP

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -302,12 +302,12 @@
       "description": "A Docker container management plugin for RaspAP",
       "author": "RaspAP",
       "author_uri": "https://github.com/RaspAP",
-      "plugin_uri": "https://github.com/cyrus104/raspap-insiders/tree/feat/docker-plugin/plugins-available/Docker",
+      "plugin_uri": "https://github.com/cyrus104/docker-plugin",
       "plugin_docs": "https://docs.raspap.com/docker",
       "license": "GPL-3.0",
       "namespace": "RaspAP\\Plugins\\Docker",
       "icon": "fab fa-docker",
-      "install_path": "plugins-available",
+      "install_path": "plugins",
       "manifest_version": "1.0",
       "default_locale": "en_US"
     }

--- a/manifest.json
+++ b/manifest.json
@@ -294,7 +294,22 @@
         "www-data ALL=(ALL) NOPASSWD:/bin/cp /tmp/nodogsplash.conf /etc/nodogsplash/nodogsplash.conf",
         "www-data ALL=(ALL) NOPASSWD:/usr/bin/ndsctl *"
       ]
+    },
+    {
+      "id": "9",
+      "name": "Docker",
+      "version": "v1.0.0",
+      "description": "A Docker container management plugin for RaspAP",
+      "author": "RaspAP",
+      "author_uri": "https://github.com/RaspAP",
+      "plugin_uri": "https://github.com/cyrus104/raspap-insiders/tree/feat/docker-plugin/plugins-available/Docker",
+      "plugin_docs": "https://docs.raspap.com/docker",
+      "license": "GPL-3.0",
+      "namespace": "RaspAP\\Plugins\\Docker",
+      "icon": "fab fa-docker",
+      "install_path": "plugins-available",
+      "manifest_version": "1.0",
+      "default_locale": "en_US"
     }
   ]
 }
-

--- a/manifest.json
+++ b/manifest.json
@@ -300,8 +300,8 @@
       "name": "Docker",
       "version": "v1.0.0",
       "description": "A Docker container management plugin for RaspAP",
-      "author": "RaspAP",
-      "author_uri": "https://github.com/RaspAP",
+      "author": "cyrus104",
+      "author_uri": "https://github.com/cyrus104",
       "plugin_uri": "https://github.com/cyrus104/docker-plugin",
       "plugin_docs": "https://docs.raspap.com/docker",
       "license": "GPL-3.0",
@@ -309,7 +309,38 @@
       "icon": "fab fa-docker",
       "install_path": "plugins",
       "manifest_version": "1.0",
-      "default_locale": "en_US"
+      "default_locale": "en_US",
+      "keys": [
+        {
+          "key_url": "https://download.docker.com/linux/debian/gpg",
+          "keyring": "/usr/share/keyrings/docker-archive-keyring.gpg",
+          "repo": "https://download.docker.com/linux/debian",
+          "sources": "/etc/apt/sources.list.d/docker.list"
+        }
+      ],
+      "dependencies": {
+        "docker-ce": "latest",
+        "docker-ce-cli": "latest",
+        "containerd.io": "latest",
+        "docker-buildx-plugin": "latest",
+        "docker-compose-plugin": "latest"
+      },
+      "configuration": [
+        {
+          "source": "config/.gitkeep",
+          "destination": "/etc/raspap/docker/compose/.gitkeep"
+        }
+      ],
+      "sudoers": [
+        "www-data ALL=(ALL) NOPASSWD:/usr/bin/docker *",
+        "www-data ALL=(ALL) NOPASSWD:/usr/bin/docker compose *",
+        "www-data ALL=(ALL) NOPASSWD:/bin/systemctl start docker",
+        "www-data ALL=(ALL) NOPASSWD:/bin/systemctl stop docker",
+        "www-data ALL=(ALL) NOPASSWD:/bin/ls *"
+      ],
+      "javascript": {
+        "source": "app/js/Docker.js"
+      }
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -313,8 +313,8 @@
       "keys": [
         {
           "key_url": "https://download.docker.com/linux/debian/gpg",
-          "keyring": "/usr/share/keyrings/docker-archive-keyring.gpg",
-          "repo": "https://download.docker.com/linux/debian",
+          "keyring": "/etc/apt/keyrings/docker.asc",
+          "repo": "config/docker.list",
           "sources": "/etc/apt/sources.list.d/docker.list"
         }
       ],

--- a/manifest.json
+++ b/manifest.json
@@ -298,7 +298,7 @@
     {
       "id": "9",
       "name": "Docker",
-      "version": "v1.0.0",
+      "version": "v1.1.0",
       "description": "A Docker container management plugin for RaspAP",
       "author": "cyrus104",
       "author_uri": "https://github.com/cyrus104",
@@ -329,6 +329,18 @@
         {
           "source": "config/.gitkeep",
           "destination": "/etc/raspap/docker/compose/.gitkeep"
+        },
+        {
+          "source": "config/docker_plugin_update.sh",
+          "destination": "/etc/raspap/docker/docker_plugin_update.sh"
+        }
+      ],
+      "permissions": [
+        {
+          "file": "/etc/raspap/docker/docker_plugin_update.sh",
+          "owner": "root",
+          "group": "root",
+          "mode": "0755"
         }
       ],
       "sudoers": [
@@ -336,7 +348,8 @@
         "www-data ALL=(ALL) NOPASSWD:/usr/bin/docker compose *",
         "www-data ALL=(ALL) NOPASSWD:/bin/systemctl start docker",
         "www-data ALL=(ALL) NOPASSWD:/bin/systemctl stop docker",
-        "www-data ALL=(ALL) NOPASSWD:/bin/ls *"
+        "www-data ALL=(ALL) NOPASSWD:/bin/ls *",
+        "www-data ALL=(ALL) NOPASSWD:/etc/raspap/docker/docker_plugin_update.sh *"
       ],
       "javascript": {
         "source": "app/js/Docker.js"


### PR DESCRIPTION
The Docker plugin adds a full Docker container management interface directly into the RaspAP web UI. Here's what it does as a whole:
                                                                                                                                                                                                                                     
  - Installs Docker (docker-ce, docker-cli, containerd, buildx, compose) via apt on the Raspberry Pi using Docker's official repository
  - Manages containers — start, stop, remove containers from the UI without SSH                                                                                                                                                      
  - Docker Compose support — deploy and manage multi-container stacks through the web interface                                                                                                                
  - Image management — pull images from Docker Hub, browse and remove local images                                                                                                                                                   
  - Volume browsing — inspect Docker volumes directly from the browser
  - Service control — start/stop the Docker daemon via systemctl from the UI                                                                                                                                                         
  - Status indicator — live service status shown in the sidebar alongside other RaspAP modules     